### PR TITLE
Fix incorrect output for halfwidth katakana keys

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var sjisconv = require('./lib/sjisconv');
 var SALT_TABLE = '.............................................../0123456789A'
   + 'BCDEFGABCDEFGHIJKLMNOPQRSTUVWXYZabcdefabcdefghijklmnopqrstuvwxyz..........'
   + '..........................................................................'
-  + '.................................................'.split('');
+  + '.................................................';
 
 function sjis(str) {
   var encoded = '';

--- a/test/index.js
+++ b/test/index.js
@@ -88,3 +88,9 @@ test('collisions', function(t) {
   // !c8eDXvwFLQ
   t.equal(tripcode('fa'), tripcode(utf8.decode('\xE8\xA8\x9B')));
 });
+
+test('half width katakana', function(t) {
+  t.plan(1);
+
+  t.equal(tripcode('ﾐﾐ'), '8wihCLEUuc');
+});


### PR DESCRIPTION
Replacing this pull request https://github.com/KenanY/tripcode/pull/73 concerning the same problem, adding a test case.